### PR TITLE
implements ser/de for `NamespacedId`s in recipes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_with = "1.6.4"

--- a/src/datapack/recipe.rs
+++ b/src/datapack/recipe.rs
@@ -1,7 +1,8 @@
 use crate::{
     internal_prelude::*,
-    misc::namespaced_id::recipe_advancement_serde
+    misc::namespaced_id::FieldTaggedNamespacedId,
 };
+use serde_with::serde_as;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Recipe {
@@ -12,57 +13,63 @@ pub struct Recipe {
     pub variant: RecipeVariant,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CookingRecipeCommon {
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "FieldTaggedNamespacedId")]
     pub ingredient: NamespacedId,
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "FieldTaggedNamespacedId")]
     pub result: NamespacedId,
     pub experience: f64,
     #[serde(rename = "cookingtime")]
     pub cooking_time: Option<i32>,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CraftingShapedRecipe {
     pub pattern: Vec<String>,
     #[serde(default)]
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "Vec<FieldTaggedNamespacedId>")]
     pub ingredients: Vec<NamespacedId>,
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "HashMap<_, FieldTaggedNamespacedId>")]
     pub key: HashMap<char, NamespacedId>,
     pub result: RecipeResultWithCount,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CraftingShapelessRecipe {
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "Vec<FieldTaggedNamespacedId>")]
     pub ingredients: Vec<NamespacedId>,
     pub result: RecipeResultWithCount,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct RecipeResultWithCount {
     pub count: Option<i32>,
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "FieldTaggedNamespacedId")]
     pub item: NamespacedId,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SmithingRecipe {
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "FieldTaggedNamespacedId")]
     pub base: NamespacedId,
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "FieldTaggedNamespacedId")]
     pub addition: NamespacedId,
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "FieldTaggedNamespacedId")]
     pub result: NamespacedId,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StonecuttingRecipe {
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "FieldTaggedNamespacedId")]
     pub ingredient: NamespacedId,
-    #[serde(with = "recipe_advancement_serde")]
+    #[serde_as(as = "FieldTaggedNamespacedId")]
     pub result: NamespacedId,
     pub count: i32,
 }

--- a/src/datapack/recipe.rs
+++ b/src/datapack/recipe.rs
@@ -3,7 +3,7 @@ use serde_with::serde_as;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Recipe {
-    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
     #[serde(flatten)]
     pub variant: RecipeVariant,
@@ -43,6 +43,7 @@ pub enum Ingredient {
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct RecipeResultWithCount {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<i32>,
     #[serde_as(as = "FieldTaggedNamespacedId")]
     #[serde(flatten)]

--- a/src/datapack/recipe.rs
+++ b/src/datapack/recipe.rs
@@ -1,7 +1,11 @@
-use crate::internal_prelude::*;
+use crate::{
+    internal_prelude::*,
+    misc::namespaced_id::recipe_advancement_serde
+};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Recipe {
+    #[serde(flatten)]
     pub group: Option<String>,
 
     #[serde(flatten)]
@@ -10,7 +14,9 @@ pub struct Recipe {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CookingRecipeCommon {
+    #[serde(with = "recipe_advancement_serde")]
     pub ingredient: NamespacedId,
+    #[serde(with = "recipe_advancement_serde")]
     pub result: NamespacedId,
     pub experience: f64,
     #[serde(rename = "cookingtime")]
@@ -19,14 +25,18 @@ pub struct CookingRecipeCommon {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CraftingShapedRecipe {
-    pub pattern: (String, String, String),
+    pub pattern: Vec<String>,
+    #[serde(default)]
+    #[serde(with = "recipe_advancement_serde")]
     pub ingredients: Vec<NamespacedId>,
+    #[serde(with = "recipe_advancement_serde")]
     pub key: HashMap<char, NamespacedId>,
     pub result: RecipeResultWithCount,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CraftingShapelessRecipe {
+    #[serde(with = "recipe_advancement_serde")]
     pub ingredients: Vec<NamespacedId>,
     pub result: RecipeResultWithCount,
 }
@@ -34,19 +44,25 @@ pub struct CraftingShapelessRecipe {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct RecipeResultWithCount {
     pub count: Option<i32>,
+    #[serde(with = "recipe_advancement_serde")]
     pub item: NamespacedId,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SmithingRecipe {
+    #[serde(with = "recipe_advancement_serde")]
     pub base: NamespacedId,
+    #[serde(with = "recipe_advancement_serde")]
     pub addition: NamespacedId,
+    #[serde(with = "recipe_advancement_serde")]
     pub result: NamespacedId,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StonecuttingRecipe {
+    #[serde(with = "recipe_advancement_serde")]
     pub ingredient: NamespacedId,
+    #[serde(with = "recipe_advancement_serde")]
     pub result: NamespacedId,
     pub count: i32,
 }
@@ -54,46 +70,46 @@ pub struct StonecuttingRecipe {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum RecipeVariant {
-    #[serde(rename = "blasting")]
+    #[serde(rename = "minecraft:blasting")]
     Blasting(CookingRecipeCommon),
-    #[serde(rename = "campfire_cooking")]
+    #[serde(rename = "minecraft:campfire_cooking")]
     CampfireCooking(CookingRecipeCommon),
-    #[serde(rename = "crafting_shaped")]
+    #[serde(rename = "minecraft:crafting_shaped")]
     CraftingShaped(CraftingShapedRecipe),
-    #[serde(rename = "crafting_shapeless")]
+    #[serde(rename = "minecraft:crafting_shapeless")]
     CraftingShapeless(CraftingShapelessRecipe),
-    #[serde(rename = "smelting")]
+    #[serde(rename = "minecraft:smelting")]
     Smelting(CookingRecipeCommon),
-    #[serde(rename = "smithing")]
+    #[serde(rename = "minecraft:smithing")]
     Smithing(SmithingRecipe),
-    #[serde(rename = "smoking")]
+    #[serde(rename = "minecraft:smoking")]
     Smoking(CookingRecipeCommon),
-    #[serde(rename = "stonecutting")]
+    #[serde(rename = "minecraft:stonecutting")]
     Stonecutting(StonecuttingRecipe),
-    #[serde(rename = "crafting_special_armordye")]
+    #[serde(rename = "minecraft:crafting_special_armordye")]
     CraftingSpecialArmorDye,
-    #[serde(rename = "crafting_special_bannerduplicate")]
+    #[serde(rename = "minecraft:crafting_special_bannerduplicate")]
     CraftingSpecialBannerDuplicate,
-    #[serde(rename = "crafting_special_bookcloning")]
+    #[serde(rename = "minecraft:crafting_special_bookcloning")]
     CraftingSpecialBookCloning,
-    #[serde(rename = "crafting_special_firework_rocket")]
+    #[serde(rename = "minecraft:crafting_special_firework_rocket")]
     CraftingSpecialFireworkRocket,
-    #[serde(rename = "crafting_special_firework_star")]
+    #[serde(rename = "minecraft:crafting_special_firework_star")]
     CraftingSpecialFireworkStar,
-    #[serde(rename = "crafting_special_firework_star_fade")]
+    #[serde(rename = "minecraft:crafting_special_firework_star_fade")]
     CraftingSpecialFireworkStarFade,
-    #[serde(rename = "crafting_special_mapcloning")]
+    #[serde(rename = "minecraft:crafting_special_mapcloning")]
     CraftingSpecialMapCloning,
-    #[serde(rename = "crafting_special_mapextending")]
+    #[serde(rename = "minecraft:crafting_special_mapextending")]
     CraftingSpecialMapExtending,
-    #[serde(rename = "crafting_special_repairitem")]
+    #[serde(rename = "minecraft:crafting_special_repairitem")]
     CraftingSpecialRepairItem,
-    #[serde(rename = "crafting_special_shielddecoration")]
+    #[serde(rename = "minecraft:crafting_special_shielddecoration")]
     CraftingSpecialShieldDecoration,
-    #[serde(rename = "crafting_special_shulkerboxcoloring")]
+    #[serde(rename = "minecraft:crafting_special_shulkerboxcoloring")]
     CraftingSpecialShulkerBoxColoring,
-    #[serde(rename = "crafting_special_tippedarrow")]
+    #[serde(rename = "minecraft:crafting_special_tippedarrow")]
     CraftingSpecialTippedArrow,
-    #[serde(rename = "crafting_special_suspiciousstew")]
+    #[serde(rename = "minecraft:crafting_special_suspiciousstew")]
     CraftingSpecialSuspiciousStew,
 }

--- a/src/datapack/recipe.rs
+++ b/src/datapack/recipe.rs
@@ -1,24 +1,17 @@
-use crate::{
-    internal_prelude::*,
-    misc::namespaced_id::FieldTaggedNamespacedId,
-};
+use crate::{internal_prelude::*, misc::namespaced_id::FieldTaggedNamespacedId};
 use serde_with::serde_as;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Recipe {
     #[serde(flatten)]
     pub group: Option<String>,
-
     #[serde(flatten)]
     pub variant: RecipeVariant,
 }
 
-#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CookingRecipeCommon {
-    #[serde_as(as = "FieldTaggedNamespacedId")]
-    pub ingredient: NamespacedId,
-    #[serde_as(as = "FieldTaggedNamespacedId")]
+    pub ingredient: Ingredient,
     pub result: NamespacedId,
     pub experience: f64,
     #[serde(rename = "cookingtime")]
@@ -29,20 +22,22 @@ pub struct CookingRecipeCommon {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CraftingShapedRecipe {
     pub pattern: Vec<String>,
-    #[serde(default)]
-    #[serde_as(as = "Vec<FieldTaggedNamespacedId>")]
-    pub ingredients: Vec<NamespacedId>,
-    #[serde_as(as = "HashMap<_, FieldTaggedNamespacedId>")]
-    pub key: HashMap<char, NamespacedId>,
+    pub key: HashMap<char, Ingredient>,
+    pub result: RecipeResultWithCount,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CraftingShapelessRecipe {
+    pub ingredients: Vec<Ingredient>,
     pub result: RecipeResultWithCount,
 }
 
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct CraftingShapelessRecipe {
-    #[serde_as(as = "Vec<FieldTaggedNamespacedId>")]
-    pub ingredients: Vec<NamespacedId>,
-    pub result: RecipeResultWithCount,
+#[serde(untagged)]
+pub enum Ingredient {
+    Specific(#[serde_as(as = "FieldTaggedNamespacedId")] NamespacedId),
+    Selection(#[serde_as(as = "Vec<FieldTaggedNamespacedId>")] Vec<NamespacedId>),
 }
 
 #[serde_as]
@@ -50,6 +45,7 @@ pub struct CraftingShapelessRecipe {
 pub struct RecipeResultWithCount {
     pub count: Option<i32>,
     #[serde_as(as = "FieldTaggedNamespacedId")]
+    #[serde(flatten)]
     pub item: NamespacedId,
 }
 
@@ -64,12 +60,9 @@ pub struct SmithingRecipe {
     pub result: NamespacedId,
 }
 
-#[serde_as]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StonecuttingRecipe {
-    #[serde_as(as = "FieldTaggedNamespacedId")]
-    pub ingredient: NamespacedId,
-    #[serde_as(as = "FieldTaggedNamespacedId")]
+    pub ingredient: Ingredient,
     pub result: NamespacedId,
     pub count: i32,
 }

--- a/src/misc/namespaced_id.rs
+++ b/src/misc/namespaced_id.rs
@@ -1,5 +1,5 @@
-use crate::internal_prelude::*;
 pub use self::field_tagged_namespaced_id::FieldTaggedNamespacedId;
+use crate::internal_prelude::*;
 /**
     Namespaced Ids are used as identifiers for various resources in Minecraft.
     See the [wiki page](https://minecraft.gamepedia.com/Namespaced_ID) for more details.
@@ -13,7 +13,13 @@ pub struct NamespacedId {
 
 impl NamespacedId {
     /// Create a new NamespacedId
-    pub fn new(is_tag: bool, namespace: &str, id: &str) -> Result<Self, InvalidNamespacedIdError> {
+    pub fn new<S: Into<String>>(
+        is_tag: bool,
+        namespace: S,
+        id: S,
+    ) -> Result<Self, InvalidNamespacedIdError> {
+        let namespace = namespace.into();
+        let id = id.into();
         // Validate namespace [a-zA-Z0-9_-]
         for (position, kind) in namespace.chars().enumerate() {
             if !(kind.is_alphanumeric() || kind == '_' || kind == '-') {
@@ -30,8 +36,8 @@ impl NamespacedId {
         }
 
         Ok(NamespacedId {
-            namespace: namespace.to_string(),
-            id: id.to_string(),
+            namespace,
+            id,
             is_tag,
         })
     }
@@ -174,27 +180,27 @@ impl<'de> Deserialize<'de> for NamespacedId {
 }
 
 pub(crate) mod field_tagged_namespaced_id {
-    use super::{
-        NamespacedId,
-        InvalidNamespacedIdError
-    };
+    use super::{InvalidNamespacedIdError, NamespacedId};
     use serde::{
-        ser::{SerializeStruct, Serializer},
         de::{self, MapAccess, Visitor},
-        Deserializer
+        ser::{SerializeStruct, Serializer},
+        Deserializer,
     };
+    use serde_with::{DeserializeAs, SerializeAs};
     use std::fmt;
-    use serde_with::{SerializeAs, DeserializeAs};
 
     pub struct FieldTaggedNamespacedId;
 
     impl SerializeAs<NamespacedId> for FieldTaggedNamespacedId {
         fn serialize_as<S>(namespaced_id: &NamespacedId, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
+        where
+            S: Serializer,
         {
             let mut state = serializer.serialize_struct("NamespacedId", 1)?;
-            state.serialize_field(if namespaced_id.is_tag { "tag" } else { "item" }, &namespaced_id.to_string())?;
+            state.serialize_field(
+                if namespaced_id.is_tag { "tag" } else { "item" },
+                &namespaced_id.to_string(),
+            )?;
             state.end()
         }
     }
@@ -211,8 +217,8 @@ pub(crate) mod field_tagged_namespaced_id {
 
     impl<'de> DeserializeAs<'de, NamespacedId> for FieldTaggedNamespacedId {
         fn deserialize_as<D>(deserializer: D) -> Result<NamespacedId, D::Error>
-            where
-                D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
         {
             deserializer.deserialize_map(NamespacedIdVisitor)
         }
@@ -232,12 +238,12 @@ pub(crate) mod field_tagged_namespaced_id {
         where
             A: MapAccess<'de>,
         {
-            let (is_tag, value) = match map.next_entry()? {
+            let (is_tag, value) = match map.next_entry::<String, String>()? {
                 Some((key, value)) => (
-                    match key {
+                    match key.as_str() {
                         "item" => false,
                         "tag" => true,
-                        _ => Err(de::Error::unknown_field(value, &["item", "tag"]))?,
+                        _ => Err(de::Error::unknown_field(&value, &["item", "tag"]))?,
                     },
                     value,
                 ),
@@ -248,7 +254,7 @@ pub(crate) mod field_tagged_namespaced_id {
                 Err(de::Error::unknown_field(key, &["item", "tag"]))?
             }
 
-            let (ns, id) = parse_namespace_and_id(value).map_err(de::Error::custom)?;
+            let (ns, id) = parse_namespace_and_id(&value).map_err(de::Error::custom)?;
             Ok(NamespacedId::new(is_tag, ns, id).unwrap())
         }
     }

--- a/src/misc/namespaced_id.rs
+++ b/src/misc/namespaced_id.rs
@@ -243,15 +243,15 @@ pub(crate) mod field_tagged_namespaced_id {
                     match key.as_str() {
                         "item" => false,
                         "tag" => true,
-                        _ => Err(de::Error::unknown_field(&value, &["item", "tag"]))?,
+                        _ => return Err(de::Error::unknown_field(&value, &["item", "tag"])),
                     },
                     value,
                 ),
-                None => Err(de::Error::invalid_length(0, &"a length of 1"))?,
+                None => return Err(de::Error::invalid_length(0, &"a length of 1")),
             };
 
             if let Some(key) = map.next_key()? {
-                Err(de::Error::unknown_field(key, &["item", "tag"]))?
+                return Err(de::Error::unknown_field(key, &["item", "tag"]));
             }
 
             let (ns, id) = parse_namespace_and_id(&value).map_err(de::Error::custom)?;

--- a/src/misc/namespaced_id.rs
+++ b/src/misc/namespaced_id.rs
@@ -199,7 +199,7 @@ pub(crate) mod field_tagged_namespaced_id {
             let mut state = serializer.serialize_struct("NamespacedId", 1)?;
             state.serialize_field(
                 if namespaced_id.is_tag { "tag" } else { "item" },
-                &namespaced_id.to_string(),
+                &format!("{}:{}", namespaced_id.namespace(), namespaced_id.id(),),
             )?;
             state.end()
         }


### PR DESCRIPTION
This is supposed to fix #1, but currently there are still some odd errors from `serde` in the deserialization process.